### PR TITLE
stop copying __mocks__ to dist

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@tsconfig/node16/tsconfig.json",
   "include": ["src"],
-  "exclude": ["node_modules", "src/**/*.spec.ts"],
+  "exclude": ["node_modules", "src/**/*.spec.ts", "src/__mocks__/"],
   "compilerOptions": {
     "outDir": "dist",
     "noImplicitAny": false


### PR DESCRIPTION
This PR fixes a `jest` warning when running the unit tests with an existing `__mocks__` directory.